### PR TITLE
Add select_streams option (to be added in the config file) to generate catalog file with some stream(s) pre-selected

### DIFF
--- a/tap_google_sheets/__init__.py
+++ b/tap_google_sheets/__init__.py
@@ -20,10 +20,10 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover(client, spreadsheet_id):
+def do_discover(client, spreadsheet_id, select_streams):
 
     LOGGER.info('Starting discover')
-    catalog = discover(client, spreadsheet_id)
+    catalog = discover(client, spreadsheet_id, select_streams)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
@@ -44,9 +44,10 @@ def main():
 
         config = parsed_args.config
         spreadsheet_id = config.get('spreadsheet_id')
+        select_streams = config.get('select_streams')
 
         if parsed_args.discover:
-            do_discover(client, spreadsheet_id)
+            do_discover(client, spreadsheet_id, select_streams)
         elif parsed_args.catalog:
             sync(client=client,
                  config=config,

--- a/tap_google_sheets/discover.py
+++ b/tap_google_sheets/discover.py
@@ -2,11 +2,13 @@ from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_google_sheets.schema import get_schemas, STREAMS
 
 
-def discover(client, spreadsheet_id):
+def discover(client, spreadsheet_id, select_streams):
     schemas, field_metadata = get_schemas(client, spreadsheet_id)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
+        if select_streams and stream_name in select_streams:
+            schema_dict['selected'] = True
         schema = Schema.from_dict(schema_dict)
         mdata = field_metadata[stream_name]
         key_properties = None


### PR DESCRIPTION
Hi,

First of all, apologies if I should have waited for an issue to be approved before creating this PR. It's just that I really need this feature, and I was going to use my forked repo; but then I thought maybe it would be helpful for everyone. I would love your opinion on this.

# Description of change
It's very weird to me one needs to run the `discovery` mode, and then somehow (manually, programmatically, or even with tools like [singer-discover](https://github.com/chrisgoddard/singer-discover)) change the `catalog` file in order to select which stream you want to retrieve data from in the `sync` step (which will probably be sheets, in this case).

Singer taps are a great tool and I think it should be as plug-and-play as possible; and if one uses it when running periodic tasks (which is my case), it just doesn't make sense to manually change any file. Personally, I don't like the idea of programmatically changing the `catalog` file (as, to be honest, I've seen some people doing) if there's a way to generate it with the desired stream already selected.

The idea here is to add the possibility of including an option in the `config` file, so the discovery part generates the `catalog.json` with a (or some) stream(s) pre-selected. This way, there's no intermediate step between the discovery and the sync, in order to get the data you want.

The solution is based on the fact that:
- when running `sync`: https://github.com/singer-io/tap-google-sheets/blob/4d4082c829/tap_google_sheets/sync.py#L362
- you check if the stream is selected: https://github.com/singer-io/singer-python/blob/6c6c773d8b/singer/catalog.py#L47
  - one way is to check if the schema is selected.

Relates to https://github.com/singer-io/tap-google-sheets/issues/8

# Manual QA steps
- Include the option `select_streams` in the config file:
  - it should be an array of strings (i.e. the names of the streams);
  - you can use pre-defined streams (e.g. `file_metadata`) or the name of the sheet (e.g. `Sheet 1`)
- the discovery step (`tap-google-sheets --config config.json --discover > catalog.json`) should generate the catalog file with the option `"selected": true` in the schema corresponding to the stream defined in the `select_streams` option.
 
# Risks
 - Not sure if `select_streams` is the best name.
 
# Rollback steps
 - revert this branch
