### PR TITLE
Emit state during incremental sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Emit state file for incremental sync where bookmark not exceeded.
+
 ## 1.0.0
   * No change from `v0.0.4`
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -388,6 +388,8 @@ def sync(client, config, catalog, state):
     LOGGER.info('last_datetime = {}, this_datetime = {}'.format(last_datetime, this_datetime))
     if this_datetime <= last_datetime:
         LOGGER.info('this_datetime <= last_datetime, FILE NOT CHANGED. EXITING.')
+        # Update file_metadata bookmark
+        write_bookmark(state, 'file_metadata', strftime(this_datetime))
         return
     # Sync file_metadata if selected
     sync_stream(stream_name, selected_streams, catalog, state, file_metadata_tf, time_extracted)


### PR DESCRIPTION
# Description of change
Emits state during incremental sync where bookmark not exceeded. 

Currently, for a execution use case as follows:

```bash
tap-google-sheets --config tap_config.json --catalog catalog.json --state previous_state.json | target-json > state.json
```

and where bookmark not exceeded by data in extraction, `state.json` will be written as blank. 

Change ensures previous state, `previous_state.json`, is written out as current state, `state.json`. 

# Manual QA steps
Performed initial and incremental sync testing that state file written and expected records are produced.
 
# Risks
Clients expecting no state file to be emitted in this workflow case may break.
 
# Rollback steps
 - revert this branch
