### PR TITLE
v.1.0.3 Fix slashes and discovery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Fix issues: slashes `/` in sheet name 404 error; Discovery malformed sheet error when 2nd row final column value(s) are `NULL`.
+
 ## 1.0.2
   * Skip sheets for which we fail to generate a schema
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Fix issues: slashes `/` in sheet name 404 error; Discovery malformed sheet error when 2nd row final column value(s) are `NULL`.

# Manual QA steps
Verified errors and changed `sync.py` and `schema.py`.
Tried to run `singer-check-tap` (from singer-tools library), but this target fails for stream or column names containing special characters like `/` or `-`.
Ran Discovery mode, verified malformed sheet issue is resolved.
Ran `target-stitch` initial load and ongoing incremental sync. No errors. Verified table created in target DWH for `slash / sheet` sheet name stream (table name = `slash___sheet`). Verified `slash/column` created (column name = `slash_column`).

# Risks
Low. Tap currently in production. Existing sheet/table names are not affected. This fixes 2 issues that were preventing some tables from being created. However, you may want to roll this out to a smaller subset of clients first, and after 1-2 weeks roll out to all remaining clients.
 
# Rollback steps
Revert to v.1.0.2
