### PR TITLE
Update schema creation

### DIFF
--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -155,20 +155,7 @@ def get_sheet_schema_columns(sheet):
                 else:
                     # Interesting - order in the anyOf makes a difference.
                     # Number w/ multipleOf must be listed last, otherwise errors occur.
-                    col_properties =  {
-                        'anyOf': [
-                            {
-                                'type': 'null'
-                            },
-                            {
-                                'type': 'number',
-                                'multipleOf': 1e-15
-                            },
-                            {
-                                'type': 'string'
-                            }
-                        ]
-                    }
+                    col_properties = {'type': ['null', 'number', 'string']}
                     column_gs_type = 'numberType'
             # Catch-all to deal with other types and set to string
             # column_effective_value_type: formulaValue, errorValue, or other

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -149,6 +149,9 @@ def get_sheet_schema_columns(sheet):
                 elif column_number_format_type == 'TEXT':
                     col_properties = {'type': ['null', 'string']}
                     column_gs_type = 'stringValue'
+                elif column_number_format_type == 'NUMBER':
+                    col_properties = {'type': ['null', 'number']}
+                    column_gs_type = 'numberType'
                 else:
                     # Interesting - order in the anyOf makes a difference.
                     # Number w/ multipleOf must be listed last, otherwise errors occur.


### PR DESCRIPTION
# Description of change

While trying to integrate `tap-google-sheets` into a local [transferwise/pipelinewise](https://github.com/transferwise/pipelinewise) setup, I noticed that `pipelinewise` does not support multiple types when using `anyOf`. JSON Schema supports specifying multiple types in an array, so I thought the easiest way was to update this tap. I also added support for direct number casting.
