### PR TITLE
Add transform function to drop date of time fields

### DIFF
--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -64,6 +64,15 @@ def write_bookmark(state, stream, value):
     singer.write_state(state)
 
 
+def drop_date_on_time(schema, record):
+    for field, field_schema in schema['properties'].items():
+        if field_schema.get('format') == 'time':
+            # `time` fields come back from Google like `X days, H:M:S`
+            old_time = record[field]
+            new_time = old_time.split(',')[1].strip()
+            record[field] = new_time
+    return record
+
 # Transform/validate batch of records w/ schema and sent to target
 def process_records(catalog,
                     stream_name,
@@ -78,8 +87,9 @@ def process_records(catalog,
             # Transform record for Singer.io
             with Transformer() as transformer:
                 try:
+                    edited_record = drop_date_on_time(schema, record)
                     transformed_record = transformer.transform(
-                        record,
+                        edited_record,
                         schema,
                         stream_metadata)
                 except Exception as err:


### PR DESCRIPTION
# Description of change
This PR transforms Google Sheet Time fields from `"44241 days, 12:34:56"` to `"12:34:56"`

# Manual QA steps
 - Ran the tap with `target-stitch`'s `Validating Handler
 
# Risks
 - Low, the current tap errors because `"44241 days, 12:34:56"` is not a valid time format. So no downstream system should ever see a value like this.
 
# Rollback steps
 - revert this branch, bump the version
