### PR TITLE
Allow all schemas to fall back to a string value

### DIFF
--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -192,7 +192,7 @@ def get_sheet_schema_columns(sheet):
             }
             columns.append(column)
 
-            if column_gs_type in {'numberType.DATE_TIME', 'numberType.DATE', 'numberType.TIME'}:
+            if column_gs_type in {'numberType.DATE_TIME', 'numberType.DATE', 'numberType.TIME', 'numberType'}:
                 col_properties = {
                         'anyOf': [
                             col_properties,

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -194,11 +194,11 @@ def get_sheet_schema_columns(sheet):
 
             if column_gs_type in {'numberType.DATE_TIME', 'numberType.DATE', 'numberType.TIME', 'numberType'}:
                 col_properties = {
-                        'anyOf': [
-                            col_properties,
-                            {'type': ['null', 'string']}
-                        ]
-                    }
+                    'anyOf': [
+                        col_properties,
+                        {'type': ['null', 'string']}
+                    ]
+                }
 
             sheet_json_schema['properties'][column_name] = col_properties
 

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -192,14 +192,15 @@ def get_sheet_schema_columns(sheet):
             }
             columns.append(column)
 
-            field_schema = {
-                'anyOf': [
-                    col_properties,
-                    {'type': ['null', 'string']}
-                ]
-            }
+            if column_gs_type in {'numberType.DATE_TIME', 'numberType.DATE', 'numberType.TIME'}:
+                col_properties = {
+                        'anyOf': [
+                            col_properties,
+                            {'type': ['null', 'string']}
+                        ]
+                    }
 
-            sheet_json_schema['properties'][column_name] = field_schema
+            sheet_json_schema['properties'][column_name] = col_properties
 
         prior_header = column_name
         i = i + 1

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -152,20 +152,7 @@ def get_sheet_schema_columns(sheet):
                 else:
                     # Interesting - order in the anyOf makes a difference.
                     # Number w/ multipleOf must be listed last, otherwise errors occur.
-                    col_properties =  {
-                        'anyOf': [
-                            {
-                                'type': 'null'
-                            },
-                            {
-                                'type': 'number',
-                                'multipleOf': 1e-15
-                            },
-                            {
-                                'type': 'string'
-                            }
-                        ]
-                    }
+                    col_properties = {'type': 'number', 'multipleOf': 1e-15}
                     column_gs_type = 'numberType'
             # Catch-all to deal with other types and set to string
             # column_effective_value_type: formulaValue, errorValue, or other
@@ -205,7 +192,14 @@ def get_sheet_schema_columns(sheet):
             }
             columns.append(column)
 
-            sheet_json_schema['properties'][column_name] = col_properties
+            field_schema = {
+                'anyOf': [
+                    col_properties,
+                    {'type': ['null', 'string']}
+                ]
+            }
+
+            sheet_json_schema['properties'][column_name] = field_schema
 
         prior_header = column_name
         i = i + 1


### PR DESCRIPTION
# Description of change
This PR changes discovery to write an `anyOf` schema for all fields.

# Manual QA steps
- Made a sheet where a column gets a date-time schema, but some row after the first has a string instead of a date
- Made a sheet where a column gets a time schema
  - We currently output times like `"123 days, 12:34:56"`
- Made a sheet where a column gets a date-time schema, but some row after the first has a null cell

On `master`, the tap fails with transform errors for the first two test cases. On this branch, there are no transform errors and the records emitted have string values as expected.

On this branch, for the null cell test case, no transform error occurs and a `null` is emitted as expected.
 
# Risks
 - For tap runs that were previously encountering a transform error, this PR will likely cause a column split in downstream systems.
 - For tap runs that were succeeding before, there should be no change.
 
# Rollback steps
 - revert this branch and bump the version
