### PR TITLE
use the v4 image for tap-tester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Description of change
Test against the v4 tap-tester image to ensure we are testing against latest services.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
