### PR TITLE
python increase to `3.8.10` version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+  * Increase python version to `3.8.10`
+
 ## 1.1.1
   * Added better error messages for 429 errors
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='1.1.1',
+      version='1.1.2',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
## 1.1.2
  * Increase python version to `3.8.10`

# Manual QA steps
 - test passes locally with python `3.8.10`
 
# Risks
 - Medium, releasing with a new python version could result in new errors not covered by the tests
 
# Rollback steps
 - revert this branch
