### PR TITLE
TDL-14397-Add skipped log when first row is empty

### DIFF
--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -65,6 +65,11 @@ def get_sheet_schema_columns(sheet):
     prior_header = None
     i = 0
     skipped = 0
+
+    # if no headers are present, log the message that sheet is skipped
+    if not headers:
+        LOGGER.warn('SKIPPING THE SHEET AS HEADERS ROW IS EMPTY. SHEET: {}'.format(sheet_title))
+
     # Read column headers until end or 2 consecutive skipped headers
     for header in headers:
         # LOGGER.info('header = {}'.format(json.dumps(header, indent=2, sort_keys=True)))
@@ -187,8 +192,6 @@ def get_sheet_schema_columns(sheet):
             sheet_json_schema['properties'].pop(prior_header, None)
             LOGGER.info('TWO CONSECUTIVE SKIPPED COLUMNS. STOPPING SCAN AT: SHEET: {}, COL: {}, CELL {}1'.format(
                 sheet_title, column_name, column_letter))
-            LOGGER.warn('SKIPPING THE SHEET AS FOUND TWO CONSECUTIVE EMPTY HEADERS. SHEET: {}'.format(
-                sheet_title))
             break
 
         else:

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -187,6 +187,8 @@ def get_sheet_schema_columns(sheet):
             sheet_json_schema['properties'].pop(prior_header, None)
             LOGGER.info('TWO CONSECUTIVE SKIPPED COLUMNS. STOPPING SCAN AT: SHEET: {}, COL: {}, CELL {}1'.format(
                 sheet_title, column_name, column_letter))
+            LOGGER.warn('SKIPPING THE SHEET AS FOUND TWO CONSECUTIVE EMPTY HEADERS. SHEET: {}'.format(
+                sheet_title))
             break
 
         else:

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.case import TestCase
 from unittest import mock
 import tap_google_sheets
 from tap_google_sheets import schema

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -12,56 +12,67 @@ class TestLogger(unittest.TestCase):
         Test if the logger statement is printed when the header row is empty and the sheet is being skipped.
         """
         sheet_data = {
-            "properties": {
-                "sheetId": 0,
-                "title":"Sheet1",
-                "index":0,
+            "properties":{
+                "sheetId":2074712559,
+                "title":"Sheet5",
+                "index":1,
                 "sheetType":"GRID",
                 "gridProperties":{
-                    "rowCount":3,
+                    "rowCount":1000,
                     "columnCount":26
                 }
             },
-            "data": [{
-                "rowData": [{
-                    "values": [
+            "data":[
+                {
+                    "rowData":[
+                        {},
                         {
-                            "effectiveFormat":{
-                                "fontFamily":"Calibri"
+                        "values":[
+                            {
+                                "userEnteredValue":{
+                                    "numberValue":1
+                                },
+                                "effectiveValue":{
+                                    "numberValue":1
+                                },
+                                "formattedValue":"1",
+                            },
+                            {
+                                "userEnteredValue":{
+                                    "numberValue":2
+                                },
+                                "effectiveValue":{
+                                    "numberValue":2
+                                },
+                                "formattedValue":"2"
+                            },
+                            {
+                                "userEnteredValue":{
+                                    "numberValue":3
+                                },
+                                "effectiveValue":{
+                                    "numberValue":3
+                                },
+                                "formattedValue":"3",
                             }
-                        },
+                        ]
+                        }
+                    ],
+                    "rowMetadata":[
                         {
-                            "effectiveFormat":{
-                                "fontFamily":"Calibri"
-                            }
-                        },
+                        "pixelSize":21
+                        }
+                    ],
+                    "columnMetadata":[
                         {
-                            "effectiveFormat":{
-                                "fontFamily":"Calibri"
-                            }
+                        "pixelSize":100
                         }
                     ]
-                },
-                {
-                    "values":[{
-                        "userEnteredValue":{
-                            "stringValue":"A"
-                        }
-                    },
-                    {
-                        "userEnteredValue":{
-                            "stringValue":"B"
-                        }
-                    },
-                    {
-                        "userEnteredValue":{
-                            "stringValue":"C"
-                        }
-                    }]
                 }
-                ]
-            }]
+            ]
         }
+        # retrieve the sheet title from the `sheet_data`
+        sheet_title = sheet_data.get('properties', {}).get('title')
         sheet_schema, columns = schema.get_sheet_schema_columns(sheet_data)
         # check if the logger is called with correct logger message
-        mocked_logger.assert_called_with('SKIPPING THE SHEET AS FOUND TWO CONSECUTIVE EMPTY HEADERS. SHEET: Sheet1')
+        mocked_logger.assert_called_with('SKIPPING THE SHEET AS HEADERS ROW IS EMPTY. SHEET: {}'.format(sheet_title))

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.case import TestCase
+from unittest import mock
+import tap_google_sheets
+from tap_google_sheets import schema
+
+
+class TestLogger(unittest.TestCase):
+    @mock.patch('tap_google_sheets.schema.LOGGER.warn')
+    def test_logger_message(self, mocked_logger):
+        sheet_data = {
+            "properties": {
+                "sheetId": 0,
+                "title":"Sheet1",
+                "index":0,
+                "sheetType":"GRID",
+                "gridProperties":{
+                    "rowCount":3,
+                    "columnCount":26
+                }
+            },
+            "data": [{
+                "rowData": [{
+                    "values": [
+                        {
+                            "effectiveFormat":{
+                                "fontFamily":"Calibri"
+                            }
+                        },
+                        {
+                            "effectiveFormat":{
+                                "fontFamily":"Calibri"
+                            }
+                        },
+                        {
+                            "effectiveFormat":{
+                                "fontFamily":"Calibri"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "values":[{
+                        "userEnteredValue":{
+                            "stringValue":"A"
+                        }
+                    },
+                    {
+                        "userEnteredValue":{
+                            "stringValue":"B"
+                        }
+                    },
+                    {
+                        "userEnteredValue":{
+                            "stringValue":"C"
+                        }
+                    }]
+                }
+                ]
+            }]
+        }
+        sheet_schema, columns = schema.get_sheet_schema_columns(sheet_data)
+        mocked_logger.assert_called_with('SKIPPING THE SHEET AS FOUND TWO CONSECUTIVE EMPTY HEADERS. SHEET: Sheet1')

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -8,6 +8,9 @@ from tap_google_sheets import schema
 class TestLogger(unittest.TestCase):
     @mock.patch('tap_google_sheets.schema.LOGGER.warn')
     def test_logger_message(self, mocked_logger):
+        """
+        Test if the logger statement is printed when the header row is empty and the sheet is being skipped.
+        """
         sheet_data = {
             "properties": {
                 "sheetId": 0,
@@ -60,4 +63,5 @@ class TestLogger(unittest.TestCase):
             }]
         }
         sheet_schema, columns = schema.get_sheet_schema_columns(sheet_data)
+        # check if the logger is called with correct logger message
         mocked_logger.assert_called_with('SKIPPING THE SHEET AS FOUND TWO CONSECUTIVE EMPTY HEADERS. SHEET: Sheet1')


### PR DESCRIPTION
# Description of change

- Add a logger message when the sheet has the first row empty (no headers) recording that the sheet is being skipped.

# Manual QA steps
 - Added a unittest that the logger message is correctly printed for no headers.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
