### PR TITLE
TDL-14409-selected-fields-in-file-metadata-are-not-being-synced

### DIFF
--- a/tests/test_google_sheets_all_fields.py
+++ b/tests/test_google_sheets_all_fields.py
@@ -80,7 +80,10 @@ class AllFields(GoogleSheetsBaseTest):
                 self.assertGreater(len(expected_all_keys), len(expected_automatic_keys))
                 self.assertTrue(expected_automatic_keys.issubset(expected_all_keys), msg=f'{expected_automatic_keys-expected_all_keys} is not in "expected_all_keys"')
                 if stream == "file_metadata":
-                    #  BUG | below keys are not synced https://jira.talendforge.org/browse/TDL-14409
+
+                    # As per google documentation https://developers.google.com/drive/api/v3/reference/files `teamDriveId` is deprecated. There is mentioned that use `driveId` instead.
+                    # `driveId` is populated from items in the team shared drives. But stitch integration does not support shared team drive. So replicating driveid is not possible.
+                    # So, these two fields will not be synced.
                     expected_all_keys.remove('teamDriveId')
                     expected_all_keys.remove('driveId')
                 self.assertSetEqual(expected_all_keys, actual_all_keys) 


### PR DESCRIPTION
# Description of change
-  As per google [Document](https://developers.google.com/drive/api/v3/reference/files) `teamDriveId` is deprecated. 
- There is mentioned that use `driveId` instead.
- `driveId` is populated from items in the team shared drives. 
- But stitch integration does not support shared team drive. So replicating driveId is not possible.
- So, these two fields will not be synced. 
- Added comment to the test case.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
