### PR TITLE
Tdl 14376 pagination failure

### DIFF
--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -514,6 +514,17 @@ def sync(client, config, catalog, state):
                             from_row=from_row,
                             columns=columns,
                             sheet_data_rows=sheet_data_rows)
+
+                        # Here row_num is the addition of from_row and total records get in response(per batch).
+                        # Condition row_num < to_row was checking that if records on the current page are less than expected(to_row) or not.
+                        # If the condition returns true then it was breaking the loop.
+                        # API does not return the last empty rows in response.
+                        # For example, rows 199 and 200 are empty, and a total of 400 rows are there in the sheet. So, in 1st iteration,
+                        # to_row = 200, from_row = 2, row_num = 2(from_row) + 197 = 199(1st row contain header value)
+                        # So, the above condition become true and breaks the loop without syncing records from 201 to 400.
+                        # sheet_data_rows is no of records return in the current page. If it's a whole blank page then stop looping.
+                        # So, in the above case, it syncs records 201 to 400 also even if rows 199 and 200 are blank.
+                        # Then when the next batch 401 to 600 is empty, it breaks the loop.
                         if not sheet_data_rows: # If a whole blank page found, then stop looping.
                             is_last_row = True
 

--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -514,7 +514,7 @@ def sync(client, config, catalog, state):
                             from_row=from_row,
                             columns=columns,
                             sheet_data_rows=sheet_data_rows)
-                        if row_num < to_row:
+                        if not sheet_data_rows: # If a whole blank page found, then stop looping.
                             is_last_row = True
 
                         # Process records, send batch of records to target

--- a/tests/test_google_sheets_pagination.py
+++ b/tests/test_google_sheets_pagination.py
@@ -44,7 +44,6 @@ class PaginationTest(GoogleSheetsBaseTest):
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
 
-        # Added back `sadsheet-pagination` to testable_streams as # BUG TDL-14376 resolved.
         for stream in testable_streams:
             with self.subTest(stream=stream):
 

--- a/tests/test_google_sheets_pagination.py
+++ b/tests/test_google_sheets_pagination.py
@@ -25,6 +25,7 @@ class PaginationTest(GoogleSheetsBaseTest):
         Verify that for each stream you can get multiple pages of data
         and that when all fields are selected more than the automatic fields are replicated.
 
+        Verify by primary keys that data is unique for page
         PREREQUISITE
         This test relies on the existence of a specific sheet with the name Pagination that has a column
         called 'id' with values 1 -> 238.
@@ -43,6 +44,7 @@ class PaginationTest(GoogleSheetsBaseTest):
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
 
+        # Added back `sadsheet-pagination` to testable_streams as # BUG TDL-14376 resolved.
         for stream in testable_streams:
             with self.subTest(stream=stream):
 
@@ -72,10 +74,25 @@ class PaginationTest(GoogleSheetsBaseTest):
                     self.assertTrue(
                         primary_keys_page_1.isdisjoint(primary_keys_page_2))
 
+                if stream == "sadsheet-pagination":
+                    # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
+                    # our fake pk value ('id')
+                    expected_pk_list = list(range(1, 238))
+                    expected_pk_list = [x for x in expected_pk_list if x not in [198, 199]]
+                    self.assertEqual(expected_pk_list, fake_pk_list)
+                    
+                    # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
+                    # the actual primary key values (__sdc_row)
+                    expected_pk_list = list(range(2, 239))
+                    expected_pk_list = [x for x in expected_pk_list if x not in [199, 200]]
+                    self.assertEqual(expected_pk_list, actual_pk_list)
+                    
+                    continue
+
                 # verify the data for the "Pagination" stream is free of any duplicates or breaks by checking
                 # our fake pk value ('id')
                 # THIS ASSERTION CAN BE MADE BECAUSE WE SETUP DATA IN A SPECIFIC WAY. DONT COPY THIS
-                self.assertEqual(list(range(1, 239)), fake_pk_list) 
+                self.assertEqual(list(range(1, 239)), fake_pk_list)
 
                 # verify the data for the "Pagination" stream is free of any duplicates or breaks by checking
                 # the actual primary key values (__sdc_row)

--- a/tests/test_google_sheets_pagination.py
+++ b/tests/test_google_sheets_pagination.py
@@ -73,18 +73,27 @@ class PaginationTest(GoogleSheetsBaseTest):
                     # Verify by primary keys that data is unique for page
                     self.assertTrue(
                         primary_keys_page_1.isdisjoint(primary_keys_page_2))
-
+                
                 if stream == "sadsheet-pagination":
                     # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
-                    # our fake pk value ('id')
-                    expected_pk_list = list(range(1, 238))
+                    # our fake pk value ('id'). 'id' is column in sheet which contains unique index 1 to 237
+                    expected_pk_list = list(range(1, 238)) # Return 1 to 237
+
+                    # Remove 198 and 199 from expected_pk_list because id by this number does not exist. 
+                    # That means those two rows are blank.
                     expected_pk_list = [x for x in expected_pk_list if x not in [198, 199]]
+
+                    # This assertion can be made because the data is in a specific way.
                     self.assertEqual(expected_pk_list, fake_pk_list)
                     
                     # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
                     # the actual primary key values (__sdc_row)
-                    expected_pk_list = list(range(2, 239))
+                    expected_pk_list = list(range(2, 239)) # Return 2 to 238. Because 1st row contains header values itself.
+
+                    # Remove 199 and 200 from expected_pk_list because __sdc_row by this number does not exist. 
+                    # That means those two rows are blank.
                     expected_pk_list = [x for x in expected_pk_list if x not in [199, 200]]
+
                     self.assertEqual(expected_pk_list, actual_pk_list)
                     
                     continue

--- a/tests/test_google_sheets_pagination.py
+++ b/tests/test_google_sheets_pagination.py
@@ -44,6 +44,7 @@ class PaginationTest(GoogleSheetsBaseTest):
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
 
+        # Added back `sadsheet-pagination` to testable_streams as # BUG TDL-14376 resolved.
         for stream in testable_streams:
             with self.subTest(stream=stream):
 
@@ -60,39 +61,18 @@ class PaginationTest(GoogleSheetsBaseTest):
                 # verify that we can paginate with all fields selected
                 self.assertGreater(record_count_by_stream.get(stream, 0), self.API_LIMIT)
 
-                record_count_sync = record_count_by_stream.get(stream, 0)
 
-                if record_count_sync > self.API_LIMIT:
-                    primary_keys_list_1 = actual_pk_list[:self.API_LIMIT]
-                    primary_keys_list_2 = actual_pk_list[self.API_LIMIT:2*self.API_LIMIT]
-
-                    primary_keys_page_1 = set(primary_keys_list_1)
-                    primary_keys_page_2 = set(primary_keys_list_2)
-
-                    # Verify by primary keys that data is unique for page
-                    self.assertTrue(
-                        primary_keys_page_1.isdisjoint(primary_keys_page_2))
-                
                 if stream == "sadsheet-pagination":
                     # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
-                    # our fake pk value ('id'). 'id' is column in sheet which contains unique index 1 to 237
-                    expected_pk_list = list(range(1, 238)) # Return 1 to 237
-
-                    # Remove 198 and 199 from expected_pk_list because id by this number does not exist. 
-                    # That means those two rows are blank.
+                    # our fake pk value ('id')
+                    expected_pk_list = list(range(1, 238))
                     expected_pk_list = [x for x in expected_pk_list if x not in [198, 199]]
-
-                    # This assertion can be made because the data is in a specific way.
                     self.assertEqual(expected_pk_list, fake_pk_list)
                     
                     # verify the data for the "sadsheet-pagination" stream is free of any duplicates or breaks by checking
                     # the actual primary key values (__sdc_row)
-                    expected_pk_list = list(range(2, 239)) # Return 2 to 238. Because 1st row contains header values itself.
-
-                    # Remove 199 and 200 from expected_pk_list because __sdc_row by this number does not exist. 
-                    # That means those two rows are blank.
+                    expected_pk_list = list(range(2, 239))
                     expected_pk_list = [x for x in expected_pk_list if x not in [199, 200]]
-
                     self.assertEqual(expected_pk_list, actual_pk_list)
                     
                     continue

--- a/tests/test_google_sheets_pagination.py
+++ b/tests/test_google_sheets_pagination.py
@@ -6,11 +6,6 @@ from tap_tester import connections, runner
 from base import GoogleSheetsBaseTest
 
 
-# BUG_TDL-14376 | https://jira.talendforge.org/browse/TDL-14376
-#                 Expectation: Tap will pick up next page (200 rows) iff there is a non-null value on that page
-#  We observed a BUG where the tap does not paginate properly on sheets where the last two rows in a batch
-# are empty values. The tap does not capture anything on the subsequent pages when this happens.
-#  
 
 
 class PaginationTest(GoogleSheetsBaseTest):


### PR DESCRIPTION
# Description of change
- Updated one condition to break out of pagination loop.
  - If a whole blank page found, then stop looping.
- Fixed pagination test case.

Note : Unittest case was not possible for this PR. We have replaced just one condition and  method which having this condition is too large and using lot of other methods. There is sync method with sync.py module. That's why to mock the other methods was not possible due to same name of method and module. So, skipped it.
# Manual QA steps
 - Verify that pagination does not break if last 2 records of any page is empty.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
