### PR TITLE
TDL-16121 typo of emailaddress corrected

### DIFF
--- a/tap_google_sheets/schemas/file_metadata.json
+++ b/tap_google_sheets/schemas/file_metadata.json
@@ -35,7 +35,7 @@
         "displayName": {
           "type": ["null", "string"]
         },
-        "emailAdress": {
+        "emailAddress": {
           "type": ["null", "string"]
         }
       }

--- a/tests/test_google_sheets_all_fields.py
+++ b/tests/test_google_sheets_all_fields.py
@@ -83,4 +83,10 @@ class AllFields(GoogleSheetsBaseTest):
                     #  BUG | below keys are not synced https://jira.talendforge.org/browse/TDL-14409
                     expected_all_keys.remove('teamDriveId')
                     expected_all_keys.remove('driveId')
+                    # Earlier field `emailAddress` was defined as `emailAdress`(typo mismatch) in file_metadata.json.
+                    # So, this particular field did not collected. Because API response contain `emailAddress` field.
+                    # Now, typo has been correted and verifying that `emailAddress` field collected.
+                    lastModifyingUser_fields = set(messages['messages'][0].get('data', {}).get('lastModifyingUser', {}).keys()) # Get `lastModifyingUser` from file_metadata records
+                    # Verify that `emailAddress` field under `lastModifyingUser` collected.
+                    self.assertTrue({'emailAddress'}.issubset(lastModifyingUser_fields), msg="emailAddress does not found in lastModifyingUser")
                 self.assertSetEqual(expected_all_keys, actual_all_keys) 


### PR DESCRIPTION
# Description of change
Corrected typo `emailAddress` field for `file_metadata` stream
Added assertion in `test_google_sheets_all_fields.py` to verify that `emailAddress` collected.
# Manual QA steps
 - Select "file_metadata" stream and run the sync mode. Then check that `emailAddress` collected.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
