### PR TITLE
TDL-16827 'str' object has no attribute 'get'

### DIFF
--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -116,12 +116,12 @@ def raise_for_error(response):
                 # There is nothing we can do here since Google has neither sent
                 # us a 2xx response nor a response content.
                 return
+            status_code = response.status_code # Get status code of the response
             response = response.json()
             if ('error' in response) or ('errorCode' in response):
-                message = '%s: %s' % (response.get('error', str(error)),
-                                      response.get('message', 'Unknown Error'))
-                error_code = response.get('error', {}).get('code')
-                ex = get_exception_for_error_code(error_code)
+                message = 'HTTP-error-code: %s %s: %s' % (status_code, response.get('error', str(error)),
+                                      response.get('message',  response.get('error_description', 'Unknown Error'))) # Check for `error_description` in response if `message` does not found
+                ex = get_exception_for_error_code(status_code)
                 raise ex(message)
             raise GoogleError(error)
         except (ValueError, TypeError):

--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -116,11 +116,14 @@ def raise_for_error(response):
                 # There is nothing we can do here since Google has neither sent
                 # us a 2xx response nor a response content.
                 return
-            status_code = response.status_code # Get status code of the response
+            # Fetch the status code from the response object itself.
+            status_code = response.status_code
             response = response.json()
             if ('error' in response) or ('errorCode' in response):
+                # To form the error message, first, check for the message. If the message is not available, check for `error_description` in response.
+                # If both are not available, raise an Unknown Error.
                 message = 'HTTP-error-code: %s %s: %s' % (status_code, response.get('error', str(error)),
-                                      response.get('message',  response.get('error_description', 'Unknown Error'))) # Check for `error_description` in response if `message` does not found
+                                      response.get('message',  response.get('error_description', 'Unknown Error')))
                 ex = get_exception_for_error_code(status_code)
                 raise ex(message)
             raise GoogleError(error)

--- a/tests/unittests/test_str_object_has_no_attribute_get.py
+++ b/tests/unittests/test_str_object_has_no_attribute_get.py
@@ -1,0 +1,53 @@
+import unittest
+from tap_google_sheets.client import raise_for_error, GoogleBadRequestError
+import requests
+
+# mock responce
+class Mockresponse:
+    def __init__(self, resp, status_code, content=[""], headers=None, raise_error=False, text={}):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+        self.text = text
+        self.reason = "error"
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.exceptions.HTTPError("mock sample message")
+
+    def json(self):
+        return self.text
+
+class TestErrorWithStrbject(unittest.TestCase):
+    """
+    Test that the tap does not break in case of a str error object in response.
+    """
+    def test_tap_handle_error_with_str_object_and_error_description(self):
+        """
+        Test that tap raise GoogleBadRequestError with status code 400 and proper message when error_description available in response.
+        """
+        error = {'error': 'invalid_grant', 'error_description': 'Bad Request'}
+        try:
+            raise_for_error(Mockresponse("", 400, raise_error=True, text=error))
+        except GoogleBadRequestError as e:
+            # Verifying the message formed for the exception
+            self.assertEqual(str(e), "HTTP-error-code: 400 invalid_grant: Bad Request")
+
+    def test_tap_handle_error_with_str_object_and_no_error_description(self):
+        """
+        Test that tap raise GoogleBadRequestError with status code 400 and Unknown Error message when error_description
+        not available in response.
+        """
+        error = {'error': 'invalid_grant'}
+        try:
+            raise_for_error(Mockresponse("", 400, raise_error=True, text=error))
+        except GoogleBadRequestError as e:
+            # Verifying the message formed for the exception
+            self.assertEqual(str(e), "HTTP-error-code: 400 invalid_grant: Unknown Error")


### PR DESCRIPTION
# Description of change
- Reading error code from `response.status_code` attribute.
- Show `error_description` in an error message if available in response.
- A written unit test case for the same.

# Manual QA steps
 - Set invalid client_id or refresh_token and raise the error.
 - Verify that tap should raise a proper error instead of AttributeError: 'str' object has no attribute 'get'
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
