### PR TITLE
Bump version to fix attribute error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1 2.1
+## 1.2.1
   * Show error_description in an error message if available in response [#59](https://github.com/singer-io/tap-google-sheets/pull/59)
 
 ## 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1 2.1
+  * Show error_description in an error message if available in response [#59](https://github.com/singer-io/tap-google-sheets/pull/59)
+
 ## 1.2.0
   * Fixed Pagination Failure [#50](https://github.com/singer-io/tap-google-sheets/pull/50)
   * Implemented Request Timeout [#54](https://github.com/singer-io/tap-google-sheets/pull/54)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='1.2.0',
+      version='1.2.1',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Tap code is throwing AttributeError: 'str' object has no attribute 'get' because of error.code missing in response.
**Resolution**
- Reading error code from response.status_code attribute.
- Showing error_description in an error message if available in response.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
