### PR TITLE
add support for shared google drives

### DIFF
--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -240,7 +240,8 @@ class FileMetadata(GoogleSheets):
     replication_method = "INCREMENTAL"
     replication_keys = ["modifiedTime"]
     params = {
-        "fields": "id,name,createdTime,modifiedTime,version,teamDriveId,driveId,lastModifyingUser"
+        "fields": "id,name,createdTime,modifiedTime,version,teamDriveId,driveId,lastModifyingUser",
+        "supportsAllDrives": True
     }
 
     def sync(self, catalog, state, selected_streams):


### PR DESCRIPTION
# Description of change
When a google sheet is in a shared google drive, the tap fails. This requires a minor adjustment to parameters. 

Resolves #7 

This supersedes #60 , which has merge conflicts with the current main branch

Tagging @Somtom @jeffhuth-bytecode @fraser to hopefully get some eyes on this. 

# Manual QA steps
- Connect to a sheet and verify the stream works
- Move the sheet to a shared drive
- Attempt connecting again and observe that it fails
- Attempt connecting again with this code change in place and observe that it works
 
# Risks
 - This is affecting many people who use the tap. Your only risk is ignoring the PR! Because people are having to fork or find alternate solutions.
 
# Rollback steps
 - revert this branch
