### PR TITLE
TDL-14386 fixed the datetime min max date ranges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(name='tap-google-sheets',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.22.0',
-          'singer-python==5.12.2'
+          'singer-python==5.12.2',
+          'cftime==1.6.0'
       ],
       extras_require={
           'test': [

--- a/tap_google_sheets/transform.py
+++ b/tap_google_sheets/transform.py
@@ -50,6 +50,11 @@ def transform_file_metadata(file_metadata):
 
 # Convert Excel Date Serial Number (excel_date_sn) to datetime string
 def excel_to_dttm_str(excel_date_sn, timezone_str=None):
+    '''
+    `cftime` provides a wide range of calenders due to its use in climate and forecasting applications.
+    Hence the larger date ranges can obe converted to string which is not available in the python's datetime
+    library. For more information on cftime, refer: https://unidata.github.io/cftime/api.html
+    '''
     reference_unit ="seconds since 1970-01-01T00:00:00Z"
     sec_per_day = 86400
     excel_epoch = 25569 # 1970-01-01T00:00:00Z, Lotus Notes Serial Number for Epoch Start Date

--- a/tests/unittests/test_datetime_transform.py
+++ b/tests/unittests/test_datetime_transform.py
@@ -1,0 +1,19 @@
+import unittest
+import cftime
+from tap_google_sheets.transform import excel_to_dttm_str
+
+class TestDateTimeTransform(unittest.TestCase):
+    """Verify that the out of range dates does not throw any exception while converting"""
+    def test_correct_string_values_when_out_of_range_max(self):
+        """Verify that the out of range date maximum does not throw any exception while converting"""
+        excel_relative_ts = 5000000
+        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
+        expected_dttm_str = cftime.num2date((excel_relative_ts-25569)*86400, "seconds since 1970-01-01T00:00:00Z", calendar='proleptic_gregorian', only_use_cftime_datetimes=True, only_use_python_datetimes=False, has_year_zero=True).strftime()
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed
+
+    def test_correct_string_values_when_out_of_range_min(self):
+        """Verify that the out of range dates minimum does not throw any exception while converting"""
+        excel_relative_ts = -694000
+        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
+        expected_dttm_str = cftime.num2date((excel_relative_ts-25569)*86400, "seconds since 1970-01-01T00:00:00Z", calendar='proleptic_gregorian', only_use_cftime_datetimes=True, only_use_python_datetimes=False, has_year_zero=True).strftime()
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed

--- a/tests/unittests/test_datetime_transform.py
+++ b/tests/unittests/test_datetime_transform.py
@@ -8,12 +8,12 @@ class TestDateTimeTransform(unittest.TestCase):
         """Verify that the out of range date maximum does not throw any exception while converting"""
         excel_relative_ts = 5000000
         return_dttm_str = excel_to_dttm_str(excel_relative_ts)
-        expected_dttm_str = cftime.num2date((excel_relative_ts-25569)*86400, "seconds since 1970-01-01T00:00:00Z", calendar='proleptic_gregorian', only_use_cftime_datetimes=True, only_use_python_datetimes=False, has_year_zero=True).strftime()
+        expected_dttm_str = '15589-07-13 00:00:00'
         self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed
 
     def test_correct_string_values_when_out_of_range_min(self):
         """Verify that the out of range dates minimum does not throw any exception while converting"""
         excel_relative_ts = -694000
         return_dttm_str = excel_to_dttm_str(excel_relative_ts)
-        expected_dttm_str = cftime.num2date((excel_relative_ts-25569)*86400, "seconds since 1970-01-01T00:00:00Z", calendar='proleptic_gregorian', only_use_cftime_datetimes=True, only_use_python_datetimes=False, has_year_zero=True).strftime()
+        expected_dttm_str = '-001-11-21 00:00:00'
         self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed


### PR DESCRIPTION
# Description of change
- Datetime/time/date values out of python datetime range(9999) fall back as a string without throwing an error

# Manual QA steps
 - Check whether the out of range dates falls back to string without throwing an error
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
