### PR TITLE
TDL-18745 changed to formatted, and made 2 API calls for datetime values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ setup(name='tap-google-sheets',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.22.0',
-          'singer-python==5.12.2',
-          'cftime==1.6.0'
+          'singer-python==5.12.2'
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(name='tap-google-sheets',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.22.0',
-          'singer-python==5.12.2'
+          'singer-python==5.12.2',
+          'cftime==1.6.0'
       ],
       extras_require={
           'test': [

--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -213,7 +213,8 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
     @backoff.on_exception(backoff.expo,
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=7,
-                          factor=3)
+                          factor=3,
+                          jitter=None)
     @utils.ratelimit(100, 100)
     def request(self, method, path=None, url=None, api=None, **kwargs):
         self.get_access_token()

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -37,7 +37,6 @@ def get_sheet_schema_columns(sheet):
     # spreadsheet is an OrderedDict, with orderd sheets and rows in the repsonse
     headers = row_data[0].get('values', [])
     first_values = row_data[1].get('values', [])
-    # LOGGER.info(f'>>>>>>> {json.dumps(first_values)}')
     # Pad first row values with default if null
     if len(first_values) < len(headers):
         pad_default_effective_values(headers, first_values)

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -37,6 +37,7 @@ def get_sheet_schema_columns(sheet):
     # spreadsheet is an OrderedDict, with orderd sheets and rows in the repsonse
     headers = row_data[0].get('values', [])
     first_values = row_data[1].get('values', [])
+    # LOGGER.info(f'>>>>>>> {json.dumps(first_values)}')
     # Pad first row values with default if null
     if len(first_values) < len(headers):
         pad_default_effective_values(headers, first_values)
@@ -157,6 +158,9 @@ def get_sheet_schema_columns(sheet):
                     }
                     column_gs_type = 'numberType.TIME'
                 elif column_number_format_type == 'TEXT':
+                    col_properties = {'type': ['null', 'string']}
+                    column_gs_type = 'stringValue'
+                elif column_number_format_type == 'CURRENCY':
                     col_properties = {'type': ['null', 'string']}
                     column_gs_type = 'stringValue'
                 else:

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -468,6 +468,7 @@ class SheetsLoadData(GoogleSheets):
 
                 # GET sheet_metadata and columns
                 sheet_schema, columns = schema.get_sheet_metadata(sheet, self.spreadsheet_id, self.client)
+                # LOGGER.info('sheet_schema: {}'.format(sheet_schema))
 
                 # SKIP empty sheets (where sheet_schema and columns are None)
                 if not sheet_schema or not columns:
@@ -475,6 +476,7 @@ class SheetsLoadData(GoogleSheets):
                 else:
                     # Transform sheet_metadata
                     sheet_metadata_transformed = internal_transform.transform_sheet_metadata(self.spreadsheet_id, sheet, columns)
+                    # LOGGER.info('sheet_metadata_transformed = {}'.format(sheet_metadata_transformed))
                     sheet_metadata.append(sheet_metadata_transformed)
 
                     # SHEET_DATA

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -2,12 +2,15 @@ import json
 import os
 import time
 import re
+import simplejson as json
 from collections import OrderedDict
 import urllib.parse
 import singer
-from singer import metrics, metadata, Transformer, utils
+import decimal
+from singer import metrics, metadata, Transformer, utils, messages
 from singer.utils import strptime_to_utc, strftime
 from singer.messages import RecordMessage
+from singer.transform import SchemaKey
 import tap_google_sheets.transform as internal_transform
 import tap_google_sheets.schema as schema
 
@@ -104,6 +107,14 @@ def get_selected_fields(catalog, stream_name):
         except IndexError:
             pass
     return selected_fields
+
+def new_format_message(message):
+    """To override the ensure_ascii param, overwitten this function"""
+    return json.dumps(message.asdict(), ensure_ascii=False, use_decimal=True)
+
+# To override the ensure_ascii param, overwitten this function of messages file of 
+# the singer module
+messages.format_message = new_format_message
 
 class GoogleSheets:
     stream_name = None
@@ -342,6 +353,94 @@ class SpreadSheetMetadata(GoogleSheets):
         # Sync spreadsheet_metadata if selected
         self.sync_stream(spreadsheet_metadata_transformed, catalog, time_extracted)
 
+def new_transform(self, data, typ, schema, path):
+    '''The new _transform function to replace in the singer module'''
+    if self.pre_hook:
+        data = self.pre_hook(data, typ, schema)
+
+    if typ == "null":
+        if data is None or data == "":
+            return True, None
+        else:
+            return False, None
+
+    elif schema.get("format") == "date-time":
+        data = self._transform_datetime(data)
+        if data is None:
+            return False, None
+
+        return True, data
+    elif schema.get("format") == "singer.decimal":
+        if data is None:
+            return False, None
+
+        if isinstance(data, (str, float, int)):
+            try:
+                return True, str(decimal.Decimal(str(data)))
+            except:
+                return False, None
+        elif isinstance(data, decimal.Decimal):
+            try:
+                if data.is_snan():
+                    return True, 'NaN'
+                else:
+                    return True, str(data)
+            except:
+                return False, None
+
+        return False, None
+    elif typ == "object":
+        # Objects do not necessarily specify properties
+        return self._transform_object(data,
+                                        schema.get("properties", {}),
+                                        path,
+                                        schema.get(SchemaKey.pattern_properties))
+
+    elif typ == "array":
+        return self._transform_array(data, schema["items"], path)
+
+    elif typ == "string":
+        if data is not None:
+            try:
+                return True, str(data)
+            except:
+                return False, None
+        else:
+            return False, None
+
+    elif typ == "integer":
+        if isinstance(data, str):
+            data = data.replace(",", "")
+
+        try:
+            return True, int(data)
+        except:
+            return False, None
+
+    elif typ == "number":
+        if isinstance(data, str):
+            data = data.replace(",", "")
+        try:
+            return True, float(data)
+        except:
+            return False, None
+
+    elif typ == "boolean":
+        # return the data as string itself if the value is of type string
+        if isinstance(data, str) and data is not None:
+            return True, data
+        try:
+            return True, bool(data)
+        except:
+            return False, None
+
+    else:
+        return False, None
+
+# To cast the boolean values differently, overwriting this function of Transformer class of 
+# the singer module
+Transformer._transform = new_transform
+
 class SheetsLoadData(GoogleSheets):
     api = "sheets"
     path = "spreadsheets/{spreadsheet_id}/values/'{sheet_title}'!{range_rows}"
@@ -350,7 +449,7 @@ class SheetsLoadData(GoogleSheets):
     replication_method = "FULL_TABLE"
     params = {
         "dateTimeRenderOption": "SERIAL_NUMBER",
-        "valueRenderOption": "UNFORMATTED_VALUE",
+        "valueRenderOption": "FORMATTED_VALUE",
         "majorDimension": "ROWS"
     }
 
@@ -358,6 +457,7 @@ class SheetsLoadData(GoogleSheets):
         """
         Load sheet's records if that sheet is selected for sync
         """
+        # LOGGER.info(f'>>>>>>>>>>>>>>> {catalog} {state} {selected_streams} {json.dumps(sheets)} {spreadsheet_time_extracted}')
         self.state = state
         sheet_metadata = []
         sheets_loaded = []
@@ -369,7 +469,7 @@ class SheetsLoadData(GoogleSheets):
 
                 # GET sheet_metadata and columns
                 sheet_schema, columns = schema.get_sheet_metadata(sheet, self.spreadsheet_id, self.client)
-                # LOGGER.info('sheet_schema: {}'.format(sheet_schema))
+                # LOGGER.info(f'sheet_schema: {sheet_schema} {columns}')
 
                 # SKIP empty sheets (where sheet_schema and columns are None)
                 if not sheet_schema or not columns:
@@ -427,10 +527,22 @@ class SheetsLoadData(GoogleSheets):
                         while not is_last_row and from_row < sheet_max_row and to_row <= sheet_max_row:
                             range_rows = 'A{}:{}{}'.format(from_row, sheet_last_col_letter, to_row)
 
+                            self.params = {
+                                "dateTimeRenderOption": "SERIAL_NUMBER",
+                                "valueRenderOption": "FORMATTED_VALUE",
+                                "majorDimension": "ROWS"
+                            }
                             # GET sheet_data for a worksheet tab
                             sheet_data, time_extracted = self.get_data(stream_name=sheet_title, range_rows=range_rows)
                             # Data is returned as a list of arrays, an array of values for each row
                             sheet_data_rows = sheet_data.get('values', [])
+                            self.params = {
+                                "dateTimeRenderOption": "SERIAL_NUMBER",
+                                "valueRenderOption": "UNFORMATTED_VALUE",
+                                "majorDimension": "ROWS"
+                            }
+                            unformatted_sheet_data, _ = self.get_data(stream_name=sheet_title, range_rows=range_rows)
+                            unformatted_sheet_data_rows = unformatted_sheet_data.get('values', [])
 
                             # Transform batch of rows to JSON with keys for each column
                             sheet_data_transformed, row_num = internal_transform.transform_sheet_data(
@@ -439,7 +551,8 @@ class SheetsLoadData(GoogleSheets):
                                 sheet_title=sheet_title,
                                 from_row=from_row,
                                 columns=columns,
-                                sheet_data_rows=sheet_data_rows)
+                                sheet_data_rows=sheet_data_rows, 
+                                unformatted_rows = unformatted_sheet_data_rows)
 
                             # Here row_num is the addition of from_row and total records get in response(per batch).
                             # Condition row_num < to_row was checking that if records on the current page are less than expected(to_row) or not.

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -457,7 +457,6 @@ class SheetsLoadData(GoogleSheets):
         """
         Load sheet's records if that sheet is selected for sync
         """
-        # LOGGER.info(f'>>>>>>>>>>>>>>> {catalog} {state} {selected_streams} {json.dumps(sheets)} {spreadsheet_time_extracted}')
         self.state = state
         sheet_metadata = []
         sheets_loaded = []
@@ -469,7 +468,6 @@ class SheetsLoadData(GoogleSheets):
 
                 # GET sheet_metadata and columns
                 sheet_schema, columns = schema.get_sheet_metadata(sheet, self.spreadsheet_id, self.client)
-                # LOGGER.info(f'sheet_schema: {sheet_schema} {columns}')
 
                 # SKIP empty sheets (where sheet_schema and columns are None)
                 if not sheet_schema or not columns:
@@ -477,7 +475,6 @@ class SheetsLoadData(GoogleSheets):
                 else:
                     # Transform sheet_metadata
                     sheet_metadata_transformed = internal_transform.transform_sheet_metadata(self.spreadsheet_id, sheet, columns)
-                    # LOGGER.info('sheet_metadata_transformed = {}'.format(sheet_metadata_transformed))
                     sheet_metadata.append(sheet_metadata_transformed)
 
                     # SHEET_DATA

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -112,8 +112,8 @@ def new_format_message(message):
     """To override the ensure_ascii param, overwitten this function"""
     return json.dumps(message.asdict(), ensure_ascii=False, use_decimal=True)
 
-# To override the ensure_ascii param, overwitten this function of messages file of 
-# the singer module
+# To override the ensure_ascii param as while writing record the currency symbols were written as ascii values,
+# overwitten this function of messages file of the singer module
 messages.format_message = new_format_message
 
 class GoogleSheets:

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -447,11 +447,7 @@ class SheetsLoadData(GoogleSheets):
     data_key = "values"
     key_properties = ["spreadsheetId", "sheetId", "loadDate"]
     replication_method = "FULL_TABLE"
-    params = {
-        "dateTimeRenderOption": "SERIAL_NUMBER",
-        "valueRenderOption": "FORMATTED_VALUE",
-        "majorDimension": "ROWS"
-    }
+    params = {}
 
     def load_data(self, catalog, state, selected_streams, sheets, spreadsheet_time_extracted):
         """

--- a/tap_google_sheets/transform.py
+++ b/tap_google_sheets/transform.py
@@ -105,6 +105,8 @@ def transform_sheet_boolean_data(value, sheet_title, col_name, col_letter, col_t
             col_val = True
         elif value.lower() in ('false', 'f', 'no', 'n'):
             col_val = False
+        # As the float and the int values would be now returned as string itself, we need to check for the special
+        # values as a string match rather than the integer/float match
         elif value in ('1', '-1', '1.00', '-1.00'):
             col_val = True
         elif value in ('0', '0.00'):

--- a/tap_google_sheets/transform.py
+++ b/tap_google_sheets/transform.py
@@ -52,7 +52,6 @@ def transform_file_metadata(file_metadata):
 def excel_to_dttm_str(string_value, excel_date_sn, timezone_str=None):
     if not timezone_str:
         timezone_str = 'UTC'
-    is_error = False
     tzn = pytz.timezone(timezone_str)
     sec_per_day = 86400
     excel_epoch = 25569 # 1970-01-01T00:00:00Z, Lotus Notes Serial Number for Epoch Start Date
@@ -63,16 +62,17 @@ def excel_to_dttm_str(string_value, excel_date_sn, timezone_str=None):
     try:
         excel_dttm = epoch_dttm + timedelta(seconds=epoch_sec)
     except OverflowError:
-        is_error = True
-        return str(string_value), is_error
+        return str(string_value), True
     utc_dttm = tzn.localize(excel_dttm).astimezone(pytz.utc)
     utc_dttm_str = strftime(utc_dttm)
-    return utc_dttm_str, is_error
+    return utc_dttm_str, False
 
 
 # transform datetime values in the sheet
 def transform_sheet_datetime_data(value, unformatted_value, sheet_title, col_name, col_letter, row_num, col_type):
     if isinstance(unformatted_value, (int, float)):
+        # passing both the formatted as well as the unformatted value, so we can use the string value in
+        # case of any errors while datetime transform
         datetime_str, _ = excel_to_dttm_str(value, unformatted_value)
         return datetime_str
     else:
@@ -83,6 +83,8 @@ def transform_sheet_datetime_data(value, unformatted_value, sheet_title, col_nam
 # transform date values in the sheet
 def transform_sheet_date_data(value, unformatted_value, sheet_title, col_name, col_letter, row_num, col_type):
     if isinstance(unformatted_value, (int, float)):
+        # passing both the formatted as well as the unformatted value, so we can use the string value in
+        # case of any errors while date transform
         date_str, is_error =  excel_to_dttm_str(value, unformatted_value)
         return_str = date_str if is_error else date_str[:10]
         return return_str

--- a/tap_google_sheets/transform.py
+++ b/tap_google_sheets/transform.py
@@ -124,6 +124,11 @@ def transform_sheet_boolean_data(value, sheet_title, col_name, col_letter, col_t
             LOGGER.info('WARNING: POSSIBLE DATA TYPE ERROR; SHEET: {}, COL: {}, CELL: {}{}, TYPE: {}'.format(
                 sheet_title, col_name, col_letter, row, col_type))
         return col_val
+    elif isinstance(value, float):
+        col_val = str(value)
+        LOGGER.info('WARNING: POSSIBLE DATA TYPE ERROR; SHEET: {}, COL: {}, CELL: {}{}, TYPE: {}'.format(
+            sheet_title, col_name, col_letter, row, col_type))
+        return col_val
 
 # transform decimal values in the sheet
 def transform_sheet_decimal_data(value, sheet_title, col_name, col_letter, row_num, col_type):
@@ -179,7 +184,7 @@ def get_column_value(value, unformatted_value, sheet_title, col_name, col_letter
 
     # NUMBER (INTEGER AND FLOAT)
     elif col_type == 'numberType':
-        return transform_sheet_number_data(value, sheet_title, col_name, col_letter, row_num, col_type)
+        return transform_sheet_number_data(unformatted_value, sheet_title, col_name, col_letter, row_num, col_type)
 
     # STRING
     elif col_type == 'stringValue':
@@ -187,7 +192,7 @@ def get_column_value(value, unformatted_value, sheet_title, col_name, col_letter
 
     # BOOLEAN
     elif col_type == 'boolValue':
-        return transform_sheet_boolean_data(value, sheet_title, col_name, col_letter, col_type, row)
+        return transform_sheet_boolean_data(unformatted_value, sheet_title, col_name, col_letter, col_type, row)
 
     # OTHER: Convert everything else to a string
     else:
@@ -203,7 +208,6 @@ def transform_sheet_data(spreadsheet_id, sheet_id, sheet_title, from_row, column
     # Create sorted list of columns based on columnIndex
     cols = sorted(columns, key=lambda i: i['columnIndex'])
 
-    # LOGGER.info('sheet_data_rows: {}'.format(sheet_data_rows))
     for (row, unformatted_row) in zip(sheet_data_rows, unformatted_rows):
         # If empty row, SKIP
         if row == []:

--- a/tests/base.py
+++ b/tests/base.py
@@ -114,6 +114,7 @@ class GoogleSheetsBaseTest(unittest.TestCase):
             "sadsheet-empty-row-2": default_sheet,
             "sadsheet-headers-only": default_sheet,
             "sadsheet-duplicate-headers-case": default_sheet,
+            "sad-sheet-effective-format": default_sheet,
             "sadsheet-column-skip-bug": {
                 self.PRIMARY_KEYS:{"__sdc_row"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,  # DOCS_BUG TDL-14240 | DOCS say INC but it is FULL

--- a/tests/base.py
+++ b/tests/base.py
@@ -116,6 +116,7 @@ class GoogleSheetsBaseTest(unittest.TestCase):
             "sadsheet-duplicate-headers-case": default_sheet,
             "sad-sheet-effective-format": default_sheet,
             "test-sheet-date": default_sheet,
+            "test-sheet-number": default_sheet,
             "sadsheet-column-skip-bug": {
                 self.PRIMARY_KEYS:{"__sdc_row"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,  # DOCS_BUG TDL-14240 | DOCS say INC but it is FULL

--- a/tests/base.py
+++ b/tests/base.py
@@ -115,6 +115,7 @@ class GoogleSheetsBaseTest(unittest.TestCase):
             "sadsheet-headers-only": default_sheet,
             "sadsheet-duplicate-headers-case": default_sheet,
             "sad-sheet-effective-format": default_sheet,
+            "test-sheet-date": default_sheet,
             "sadsheet-column-skip-bug": {
                 self.PRIMARY_KEYS:{"__sdc_row"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,  # DOCS_BUG TDL-14240 | DOCS say INC but it is FULL

--- a/tests/test_google_sheets_all_fields.py
+++ b/tests/test_google_sheets_all_fields.py
@@ -23,6 +23,7 @@ class AllFields(GoogleSheetsBaseTest):
         expected_streams = self.expected_sync_streams().difference({
             'Item Master',   # missing data for several columns
             'sadsheet-column-skip-bug',   # missing data for one column
+            'test-sheet-number', # WIP
         })
         
         # instantiate connection

--- a/tests/test_google_sheets_automatic_fields.py
+++ b/tests/test_google_sheets_automatic_fields.py
@@ -24,7 +24,7 @@ class AutomaticFields(GoogleSheetsBaseTest):
          - Verify that only the automatic fields are sent to the target.
         """
 
-        expected_streams = self.expected_sync_streams()
+        expected_streams = self.expected_sync_streams() - {'test-sheet-number'}
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_google_sheets_bookmarks.py
+++ b/tests/test_google_sheets_bookmarks.py
@@ -32,7 +32,8 @@ class BookmarksTest(GoogleSheetsBaseTest):
         skipped_streams = {stream
                            for stream in self.expected_streams()
                            if stream.startswith('sadsheet')}.union({
-                                   'file_metadata' # testing case without file_metadata selected, but still providing bookmark
+                                'test-sheet-number', # WIP
+                                'file_metadata' # testing case without file_metadata selected, but still providing bookmark
                            })
         self.expected_test_streams = self.expected_streams() - skipped_streams
 

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -82,7 +82,7 @@ class DatatypesTest(GoogleSheetsBaseTest):
         Verify tap can support data for all supported datatypes
         """
         sadsheets = {stream for stream in self.expected_sync_streams() if stream.startswith('sadsheet-')}
-        tested_streams = sadsheets.union({'happysheet', 'happysheet-string-fallback', 'sheet_metadata', 'sadsheet-date'})
+        tested_streams = sadsheets.union({'happysheet', 'happysheet-string-fallback', 'sheet_metadata', 'test-sheet-date'})
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -155,7 +155,7 @@ class DatatypesTest(GoogleSheetsBaseTest):
         # Verify that all data has been coerced to the expected column datatype
         record_data = [message['data'] for message in synced_records[test_sheet]['messages'] if message.get('data')]
         data_map = {
-	    "Currency": Decimal, # BUG Currency is being identified as a decimal type rather than string https://jira.talendforge.org/browse/TDL-14360
+	    "Currency": str, # BUG Currency is being identified as a decimal type rather than string https://jira.talendforge.org/browse/TDL-14360
 	    "Datetime": str,
             "Time": str,
             "Date": str,
@@ -234,21 +234,18 @@ class DatatypesTest(GoogleSheetsBaseTest):
 
                         elif value:
 
-                            # BUG_TDL-14369 | https://jira.talendforge.org/browse/TDL-14369
-                            #                 Skipping boolean column values becuase they do not correctly fall back to string
-                            if column == 'Boolean': # BUG_TDL-14369
-                                continue  # skip
-
                             # BUG_TDL-14448 | https://jira.talendforge.org/browse/TDL-14448
                             #                 Skipping Number and Currency columns with boolean values because they do not fallback to string
-                            elif test_case == 'boolean' and column in {'Currency', 'Number'}: # BUG_TDL-14448
+                            if test_case == 'boolean' and column in {'Currency', 'Number'}: # BUG_TDL-14448
                                 continue  # skip
 
                             # BUG_TDL-14449 |  https://jira.talendforge.org/browse/TDL-14449
                             elif test_case in {'date', 'time', 'datetime'} and column in {'Currency', 'Number'}: # BUG_TDL-14449
                                 continue  # skip
-
-
+                            
+                            if column == 'Boolean' and value  in (-1, 1, 0): # special integer values falls back to boolean
+                                self.assertTrue(isinstance(value, bool), msg=f'test case: {test_case}  value: {value}')
+                                continue
                             # verify the non-standard value has fallen back to a string type
                             self.assertTrue(isinstance(value, str), msg=f'test case: {test_case}  value: {value}')
 

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -232,7 +232,8 @@ class DatatypesTest(GoogleSheetsBaseTest):
                             # verify the expected rows are actually Null
                             self.assertIsNone(value)
 
-                        elif value:
+                        # As "'0" returns false which does not satisfy th below test case for boolean column
+                        elif value is not None or value != "":
 
                             # BUG_TDL-14448 | https://jira.talendforge.org/browse/TDL-14448
                             #                 Skipping Number and Currency columns with boolean values because they do not fallback to string

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -82,7 +82,7 @@ class DatatypesTest(GoogleSheetsBaseTest):
         Verify tap can support data for all supported datatypes
         """
         sadsheets = {stream for stream in self.expected_sync_streams() if stream.startswith('sadsheet-')}
-        tested_streams = sadsheets.union({'happysheet', 'happysheet-string-fallback', 'sheet_metadata'})
+        tested_streams = sadsheets.union({'happysheet', 'happysheet-string-fallback', 'sheet_metadata', 'sadsheet-date'})
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)
@@ -295,10 +295,6 @@ class DatatypesTest(GoogleSheetsBaseTest):
         #                 Integer is coming across as a decimal, (just the same thing as decimal)
 
 
-        # BUG TDL-14386 | https://jira.talendforge.org/browse/TDL-14386 | sadshseet-date
-        #                 Date value out of range error is not handled, tap throws critical error
-        #                    minimum date	11/21/00-1
-        #                    big date (not max)	7/13/15589
 
         # Other Bugs that do not correspond to specific sadsheet
 

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -155,7 +155,7 @@ class DatatypesTest(GoogleSheetsBaseTest):
         # Verify that all data has been coerced to the expected column datatype
         record_data = [message['data'] for message in synced_records[test_sheet]['messages'] if message.get('data')]
         data_map = {
-	    "Currency": str, # BUG Currency is being identified as a decimal type rather than string https://jira.talendforge.org/browse/TDL-14360
+	    "Currency": str,
 	    "Datetime": str,
             "Time": str,
             "Date": str,

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -1,0 +1,24 @@
+from tap_google_sheets.client import GoogleClient, Server429Error
+import unittest
+from unittest import mock
+from datetime import datetime
+
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly.
+    '''
+    @mock.patch('tap_google_sheets.client.requests.Session.request')
+    @mock.patch('tap_google_sheets.client.GoogleClient.get_access_token')
+    def test_request_timeout_and_backoff(self, mock_get_token, mock_request):
+        """
+        Check whether the request backoffs properly for request() for morthan a minute for Server429Error.
+        """
+        mock_request.side_effect = Server429Error
+        client = GoogleClient("dummy_client_id", "dummy_client_secret", "dummy_refresh_token")
+        before_time = datetime.now()
+        with self.assertRaises(Server429Error):
+            client.request("GET")
+        after_time = datetime.now()
+        # verify that the tap backoff for more than 60 seconds
+        time_difference = (after_time - before_time).total_seconds()
+        self.assertGreaterEqual(time_difference, 60)

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -11,7 +11,7 @@ class TestBackoffError(unittest.TestCase):
     @mock.patch('tap_google_sheets.client.GoogleClient.get_access_token')
     def test_request_timeout_and_backoff(self, mock_get_token, mock_request):
         """
-        Check whether the request backoffs properly for request() for morthan a minute for Server429Error.
+        Check whether the request backoffs properly for request() for more than a minute for Server429Error.
         """
         mock_request.side_effect = Server429Error
         client = GoogleClient("dummy_client_id", "dummy_client_secret", "dummy_refresh_token")

--- a/tests/unittests/test_boolean_conversion.py
+++ b/tests/unittests/test_boolean_conversion.py
@@ -1,0 +1,65 @@
+import unittest
+from singer.transform import NO_INTEGER_DATETIME_PARSING
+from tap_google_sheets.streams import new_transform
+
+schema = {
+    "properties": {
+        "__sdc_row": {
+            "type": [
+                "integer",
+                "null"
+            ]
+        },
+        "Boolean": {
+            "type": [
+                "boolean",
+                "string",
+                "null"
+            ]
+        }
+    },
+    "type": "object",
+    "additionalProperties": False
+}
+
+metadata = {(): {
+        "table-key-properties": [
+            "__sdc_row"
+        ],
+        "selected": True,
+        "forced-replication-method": "FULL_TABLE",
+        "inclusion": "available"
+    }, ("properties",
+    "__sdc_row"): {
+        "inclusion": "automatic"
+    }, ("properties",
+    "Boolean"): {
+        "inclusion": "available"
+    }
+}
+
+class MockTransformer():
+    '''Mock Request object'''
+    def __init__(self, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pre_hook=None):
+        self.integer_datetime_fmt = integer_datetime_fmt
+        self.pre_hook = pre_hook
+
+class TestBooleanDataType(unittest.TestCase):
+    def test_string_returned_for_non_string_value(self):
+        '''
+        Verify that the non boolean values returns string.
+        '''
+        data = "string"
+        transformer = MockTransformer()
+        transformed_data = new_transform(transformer, data, "boolean", schema, '')
+        print(transformed_data)
+        self.assertEqual(transformed_data[1], "string")
+
+    def test_boolean_returned_for_boolean_columns(self):
+        '''
+        Verify that the boolean values in a column returns boolean values.'''
+        data = True
+        transformer = MockTransformer()
+        transformed_data = new_transform(transformer, data, "boolean", schema, '')
+        print(transformed_data)
+        self.assertEqual(transformed_data[1], True)

--- a/tests/unittests/test_boolean_conversion.py
+++ b/tests/unittests/test_boolean_conversion.py
@@ -1,6 +1,7 @@
 import unittest
 from singer.transform import NO_INTEGER_DATETIME_PARSING
 from tap_google_sheets.streams import new_transform
+from tap_google_sheets.transform import transform_sheet_boolean_data
 
 schema = {
     "properties": {
@@ -63,3 +64,23 @@ class TestBooleanDataType(unittest.TestCase):
         transformed_data = new_transform(transformer, data, "boolean", schema, '')
         print(transformed_data)
         self.assertEqual(transformed_data[1], True)
+
+    def test_date_time_with_serial_number_1_in_boolean_col(self):
+        """
+        Verify that dattime with serial number 1 returns string date instead of true.
+        """
+        excel_relative_ts = 1
+        datetime_str = '31-12-1899'
+        return_dttm_str = transform_sheet_boolean_data(datetime_str, excel_relative_ts, "test", "boolean", "A", "boolValue", [1, "abc"])
+        expected_dttm_str = "31-12-1899"
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that string is returned
+
+    def test_date_time_with_serial_number_0_in_boolean_col(self):
+        """
+        Verify that dattime with serial number 0 returns string date instead of false.
+        """
+        excel_relative_ts = 1
+        datetime_str = '30-12-1899'
+        return_dttm_str = transform_sheet_boolean_data(datetime_str, excel_relative_ts, "test", "boolean", "A", "boolValue", [1, "abc"])
+        expected_dttm_str = "30-12-1899"
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that string is returned

--- a/tests/unittests/test_boolean_conversion.py
+++ b/tests/unittests/test_boolean_conversion.py
@@ -53,7 +53,6 @@ class TestBooleanDataType(unittest.TestCase):
         data = "string"
         transformer = MockTransformer()
         transformed_data = new_transform(transformer, data, "boolean", schema, '')
-        print(transformed_data)
         self.assertEqual(transformed_data[1], "string")
 
     def test_boolean_returned_for_boolean_columns(self):
@@ -62,7 +61,6 @@ class TestBooleanDataType(unittest.TestCase):
         data = True
         transformer = MockTransformer()
         transformed_data = new_transform(transformer, data, "boolean", schema, '')
-        print(transformed_data)
         self.assertEqual(transformed_data[1], True)
 
     def test_date_time_with_serial_number_1_in_boolean_col(self):

--- a/tests/unittests/test_currency_format.py
+++ b/tests/unittests/test_currency_format.py
@@ -1,0 +1,68 @@
+import unittest
+from tap_google_sheets import schema
+
+SHEET = {
+    "properties":{
+        "sheetId":1822945984,
+        "title":"Sheet26",
+        "index":1,
+        "sheetType":"GRID",
+        "gridProperties":{
+            "rowCount":20,
+            "columnCount":1
+        }
+    },
+    "data":[
+        {
+            "rowData":[
+                {
+                    "values":[
+                        {
+                            "formattedValue":"Column1",
+                        }
+                    ]
+                },
+                {
+                    "values":[{
+                        "userEnteredValue": {
+                            "numberValue": 878
+                        },
+                        "effectiveValue": {
+                        "numberValue": 878
+                        },
+                        "formattedValue": "£878.00",
+                        "userEnteredFormat": {
+                            "numberFormat": {
+                                "type": "CURRENCY",
+                                "pattern": "[$£-809]#,##0.00"
+                            }
+                        },
+                        "effectiveFormat": {
+                            "numberFormat": {
+                                "type": "CURRENCY",
+                                "pattern": "[$£-809]#,##0.00"
+                            }
+                        }
+                    }]
+                }
+            ]
+        }
+    ]
+}
+
+class TestNullCellFormat(unittest.TestCase):
+
+    def test_null_currency_effectiveFormat(self):
+        """
+        Test when number format currency value is given in the cell, the schema return string type
+        """
+
+        sheet = SHEET
+        expected_format = {"type": ["null", "string"]}
+
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        print(sheet_json_schema)
+        returned_formats = sheet_json_schema["properties"]["Column1"]
+
+        # verify returned schema has expected field types and format
+        self.assertEqual(expected_format, returned_formats)

--- a/tests/unittests/test_datetime_transform.py
+++ b/tests/unittests/test_datetime_transform.py
@@ -1,0 +1,19 @@
+import unittest
+import cftime
+from tap_google_sheets.transform import excel_to_dttm_str
+
+class TestDateTimeTransform(unittest.TestCase):
+    """Verify that the out of range dates does not throw any exception while converting"""
+    def test_correct_string_values_when_out_of_range_max(self):
+        """Verify that the out of range date maximum does not throw any exception while converting"""
+        excel_relative_ts = 5000000
+        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
+        expected_dttm_str = '15589-07-13 00:00:00'
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed
+
+    def test_correct_string_values_when_out_of_range_min(self):
+        """Verify that the out of range dates minimum does not throw any exception while converting"""
+        excel_relative_ts = -694000
+        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
+        expected_dttm_str = '-001-11-21 00:00:00'
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed 

--- a/tests/unittests/test_datetime_transform.py
+++ b/tests/unittests/test_datetime_transform.py
@@ -1,19 +1,32 @@
 import unittest
-import cftime
-from tap_google_sheets.transform import excel_to_dttm_str
+from tap_google_sheets.transform import transform_sheet_datetime_data, excel_to_dttm_str
 
 class TestDateTimeTransform(unittest.TestCase):
     """Verify that the out of range dates does not throw any exception while converting"""
     def test_correct_string_values_when_out_of_range_max(self):
         """Verify that the out of range date maximum does not throw any exception while converting"""
         excel_relative_ts = 5000000
-        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
-        expected_dttm_str = '15589-07-13 00:00:00'
+        expected_dttm_str = '13/07/15589 00:00:00'
+        return_dttm_str, _ = excel_to_dttm_str(expected_dttm_str, excel_relative_ts)
         self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed
 
     def test_correct_string_values_when_out_of_range_min(self):
         """Verify that the out of range dates minimum does not throw any exception while converting"""
         excel_relative_ts = -694000
-        return_dttm_str = excel_to_dttm_str(excel_relative_ts)
-        expected_dttm_str = '-001-11-21 00:00:00'
+        expected_dttm_str = '11/21/00-1 00:00:00'
+        return_dttm_str, _ = excel_to_dttm_str(expected_dttm_str, excel_relative_ts)
         self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed 
+
+    def test_correct_datetime_string_values_in_range(self):
+        """Verify that in range datetime values returns converted datetime string"""
+        excel_relative_ts = 44604.520833333336
+        datetime_str = '12/02/2022 00:00:00'
+        return_dttm_str, _ = excel_to_dttm_str(datetime_str, excel_relative_ts)
+        expected_dttm_str = "2022-02-12T12:30:00.000000Z"
+        self.assertEqual(return_dttm_str, expected_dttm_str) # Verify that the ts is correctly transformed 
+
+    def test_string_values(self):
+        """Verify that string date in a cell returns the result in same format without converting"""
+        expected_datetime_str = '12/02/2022 00:00:00'
+        return_dttm_str = transform_sheet_datetime_data(expected_datetime_str, expected_datetime_str, "test", "datetime", "A", 1, " numberType.DATE_TIME")
+        self.assertEqual(return_dttm_str, expected_datetime_str) # Verify that the ts is correctly transformed 

--- a/tests/unittests/test_null_cell_format.py
+++ b/tests/unittests/test_null_cell_format.py
@@ -39,7 +39,7 @@ SHEET = {
 }
 
 class TestNullCellFormat(unittest.TestCase):
-    
+
     def test_null_datetime_effectiveFormat(self):
         """
         Test when no value is given in second row of date-time, discovery is locking at 'effectiveFormat'.
@@ -54,14 +54,13 @@ class TestNullCellFormat(unittest.TestCase):
                             ],
                             "format": "date-time"
                         }
-        
+
         sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
         returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
-        
+
         # verify the returned schema has expected field types and format
         self.assertIn(expected_format,returned_formats)
-        
-    
+
     def test_null_date_effectiveFormat(self):
         """
         Test when no value is given in second row of date, discovery is locking at 'effectiveFormat'.
@@ -69,7 +68,7 @@ class TestNullCellFormat(unittest.TestCase):
         """
         sheet = SHEET
         sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "DATE"
-        
+
         expected_format = {
                             "type": [
                                 "null",
@@ -77,13 +76,13 @@ class TestNullCellFormat(unittest.TestCase):
                             ],
                             "format": "date"
                         }
-        
+
         sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
         returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
-        
+
         # verify the returned schema has expected field types and format
         self.assertIn(expected_format,returned_formats)
-    
+
     def test_null_time_effectiveFormat(self):
         """
         Test when no value is given in second row of time, discovery is locking at 'effectiveFormat'.
@@ -91,37 +90,33 @@ class TestNullCellFormat(unittest.TestCase):
         """
         sheet = SHEET
         sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "TIME"
-        
+
         expected_format = {
                             "type": [
                                 "null",
                                 "string"
                             ]
                         }
-        
+
         sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
         returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
-        
+
         # verify the returned schema has expected field types and format
         self.assertIn(expected_format,returned_formats)
-    
+
     def test_null_currency_effectiveFormat(self):
         """
         Test when no value is given in second row of currency, discovery is locking at 'effectiveFormat'.
         And returns type and format in schema according to that.
         """
-        
+
         sheet = SHEET
         sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "CURRENCY"
         
-        expected_format = {
-                            "type": "number",
-                            "multipleOf": 1e-15
-                        }
-        
+        expected_format = {"type": ["null", "string"]}
+
         sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
-        returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
-        
+        returned_formats = sheet_json_schema["properties"]["Column1"]
+
         # verify returned schema has expected field types and format
-        self.assertIn(expected_format,returned_formats)
-        
+        self.assertEqual(expected_format,returned_formats)

--- a/tests/unittests/test_two_api_calls_for_single_page.py
+++ b/tests/unittests/test_two_api_calls_for_single_page.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest import mock
+from tap_google_sheets.streams import SheetsLoadData
+from tap_google_sheets.client import GoogleClient
+
+sheet_schema = {'type': 'object', 'additionalProperties': False, 'properties': {'__sdc_spreadsheet_id': {'type': ['null', 'string']}, '__sdc_sheet_id': {'type': ['null', 'integer']}, '__sdc_row': {'type': ['null', 'integer']}, 'date': {'type': ['null', 'string']}, 'value': {'anyOf': [{'type': ['null', 'string'], 'format': 'date'}, {'type': ['null', 'string']}]}}}
+columns = [{'columnIndex': 1, 'columnLetter': 'A', 'columnName': 'date', 'columnType': 'stringValue', 'columnSkipped': False}, {'columnIndex': 2, 'columnLetter': 'B', 'columnName': 'value', 'columnType': 'numberType.DATE', 'columnSkipped': False}]
+
+class TestUnsupportedFields(unittest.TestCase):
+    @mock.patch('tap_google_sheets.client.GoogleClient.get')
+    @mock.patch('tap_google_sheets.streams.schema.get_sheet_metadata', return_value = [sheet_schema, columns])
+    @mock.patch('tap_google_sheets.streams.get_selected_fields', return_value = [])
+    @mock.patch('tap_google_sheets.streams.write_schema')
+    @mock.patch('tap_google_sheets.streams.GoogleSheets.process_records')
+    def test_two_api_calls(self, mock_process_records, mock_write_schema, mocked_get_selected_fields, mocked_sheet_metadata, mocked_get):
+        """
+        Verify that we make 2 API calls instead of 1 for a single page of data
+        """
+        config = {
+            "spreadsheet_id": "id",
+            "start_date": "2019-01-01T00:00:00Z"
+        }
+        sheets = [{
+            "properties": {
+            "sheetId": 1260142713,
+            "title": "Sheet13",
+            "index": 15,
+            "sheetType": "GRID",
+            "gridProperties": {
+                "rowCount": 100,
+                "columnCount": 5
+            }
+            }
+        }]
+        client = GoogleClient("dummy_client_id", "dummy_client_secret", "dummy_refresh_token", 300)
+        sheets_load_data = SheetsLoadData(client, config.get("spreadsheet_id"), config.get("start_date"))
+        sheets_load_data.load_data({}, {}, ["Sheet13"], sheets, "time")
+        self.assertEqual(mock.call(api='sheets', endpoint='Sheet13', params='dateTimeRenderOption=SERIAL_NUMBER&valueRenderOption=FORMATTED_VALUE&majorDimension=ROWS', path="spreadsheets/id/values/'Sheet13'!A2:B100"), mocked_get.mock_calls[0])
+        self.assertEqual(mock.call(api='sheets', endpoint='Sheet13', params='dateTimeRenderOption=SERIAL_NUMBER&valueRenderOption=UNFORMATTED_VALUE&majorDimension=ROWS', path="spreadsheets/id/values/'Sheet13'!A2:B100"), mocked_get.mock_calls[2]) # because also calling sheet.get('values', []) in the code
+        # Verify that the get() is called 2 times
+        self.assertEqual(mocked_get.call_count, 2)


### PR DESCRIPTION
# Description of change
- Non boolean values in boolean columns falls back as string
- Out of range valid datetimes fall back as string
- Currency is typed as string instead of decimal
- Added jitter=None

# Manual QA steps
- Verify that 2 API calls are made 
- Verify Datetime should accept out of range min-max dates
- Verify Currency is typed as string instead of decimal
- Verify Non-boolean values in boolean datatype columns fall back as string
- Verify the request backoffs for more than a minute for 429(Too many requests) error

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
