### PR TITLE
TDL-7096 used effective format to check the type instead of effective value

### DIFF
--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -96,10 +96,13 @@ def get_sheet_schema_columns(sheet):
 
             col_val = None
             if column_effective_value == {}:
-                column_effective_value_type = 'stringValue'
-                LOGGER.info('WARNING: NO VALUE IN 2ND ROW FOR HEADER. SHEET: {}, COL: {}, CELL: {}2.'.format(
-                    sheet_title, column_name, column_letter))
-                LOGGER.info('   Setting column datatype to STRING')
+                if ("numberFormat" in first_value.get('effectiveFormat', {})):
+                    column_effective_value_type = "numberValue"
+                else:
+                    column_effective_value_type = 'stringValue'
+                    LOGGER.info('WARNING: NO VALUE IN 2ND ROW FOR HEADER. SHEET: {}, COL: {}, CELL: {}2.'.format(
+                        sheet_title, column_name, column_letter))
+                    LOGGER.info('   Setting column datatype to STRING')
             else:
                 for key, val in column_effective_value.items():
                     if key in ('numberValue', 'stringValue', 'boolValue'):
@@ -125,13 +128,8 @@ def get_sheet_schema_columns(sheet):
             #  https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#NumberFormatType
             #
             column_format = None # Default
-            if column_effective_value == {}:
-                col_properties = {'type': ['null', 'string']}
-                column_gs_type = 'stringValue'
-                LOGGER.info('WARNING: 2ND ROW VALUE IS BLANK: SHEET: {}, COL: {}, CELL: {}2'.format(
-                        sheet_title, column_name, column_letter))
-                LOGGER.info('   Setting column datatype to STRING')
-            elif column_effective_value_type == 'stringValue':
+
+            if column_effective_value_type == 'stringValue':
                 col_properties = {'type': ['null', 'string']}
                 column_gs_type = 'stringValue'
             elif column_effective_value_type == 'boolValue':

--- a/tests/base.py
+++ b/tests/base.py
@@ -114,6 +114,7 @@ class GoogleSheetsBaseTest(unittest.TestCase):
             "sadsheet-empty-row-2": default_sheet,
             "sadsheet-headers-only": default_sheet,
             "sadsheet-duplicate-headers-case": default_sheet,
+            "sad-sheet-effective-format": default_sheet,
             "sadsheet-column-skip-bug": {
                 self.PRIMARY_KEYS:{"__sdc_row"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,  # DOCS_BUG TDL-14240 | DOCS say INC but it is FULL

--- a/tests/unittests/test_null_cell_format.py
+++ b/tests/unittests/test_null_cell_format.py
@@ -1,0 +1,127 @@
+import unittest
+from tap_google_sheets import schema
+
+SHEET = {
+    "properties":{
+        "sheetId":1822945984,
+        "title":"Sheet26",
+        "index":1,
+        "sheetType":"GRID",
+        "gridProperties":{
+            "rowCount":20,
+            "columnCount":1
+        }
+    },
+    "data":[
+        {
+            "rowData":[
+                {
+                    "values":[
+                        {
+                            "formattedValue":"Column1",
+                        }
+                    ]
+                },
+                {
+                    "values":[
+                        {  
+                            "effectiveFormat": {
+                                "numberFormat": {
+                                    "type": None,
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+class TestNullCellFormat(unittest.TestCase):
+    
+    def test_null_datetime_effectiveFormat(self):
+        """
+        Test when no value is given in second row of date-time, discovery is locking at 'effectiveFormat'.
+        And returns type and format in schema according to that.
+        """
+        sheet = SHEET
+        sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "DATE_TIME"
+        expected_format = {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "format": "date-time"
+                        }
+        
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
+        
+        # verify the returned schema has expected field types and format
+        self.assertIn(expected_format,returned_formats)
+        
+    
+    def test_null_date_effectiveFormat(self):
+        """
+        Test when no value is given in second row of date, discovery is locking at 'effectiveFormat'.
+        And returns type and format in schema according to that.
+        """
+        sheet = SHEET
+        sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "DATE"
+        
+        expected_format = {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "format": "date"
+                        }
+        
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
+        
+        # verify the returned schema has expected field types and format
+        self.assertIn(expected_format,returned_formats)
+    
+    def test_null_time_effectiveFormat(self):
+        """
+        Test when no value is given in second row of time, discovery is locking at 'effectiveFormat'.
+        And returns type and format in schema according to that.
+        """
+        sheet = SHEET
+        sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "TIME"
+        
+        expected_format = {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+        
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
+        
+        # verify the returned schema has expected field types and format
+        self.assertIn(expected_format,returned_formats)
+    
+    def test_null_currency_effectiveFormat(self):
+        """
+        Test when no value is given in second row of currency, discovery is locking at 'effectiveFormat'.
+        And returns type and format in schema according to that.
+        """
+        
+        sheet = SHEET
+        sheet["data"][0]["rowData"][1]["values"][0]["effectiveFormat"]["numberFormat"]["type"] = "CURRENCY"
+        
+        expected_format = {
+                            "type": "number",
+                            "multipleOf": 1e-15
+                        }
+        
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        returned_formats = sheet_json_schema["properties"]["Column1"]["anyOf"]
+        
+        # verify returned schema has expected field types and format
+        self.assertIn(expected_format,returned_formats)
+        


### PR DESCRIPTION
# Description of change
- Checked the effective_format for null cell values instead of effective_value.
- Added unittests for the same

# Manual QA steps
 - A sheet with a date_time(or any other number formatted in gsheets) column and no data in the 2nd row should be marked as a date-time(or any other number formatted in gsheets)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
