### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.1
+  * Number type falls to string for boolean values [#73](https://github.com/singer-io/tap-google-sheets/pull/73)
+  * Changed multipleof to singer.decimal [#74](https://github.com/singer-io/tap-google-sheets/pull/74)
+  * Changed to formatted, and made 2 API calls for datetime values [#75](https://github.com/singer-io/tap-google-sheets/pull/75)
+  * Checked the effective format for null cell values instead of effective value [#76](https://github.com/singer-io/tap-google-sheets/pull/76)
+
 ## 1.3.0
   * Refactor Code from Dictionary to Class based [#66]((https://github.com/singer-io/tap-google-sheets/pull/66)
   * Add Missing tap-tester cases [#65]((https://github.com/singer-io/tap-google-sheets/pull/65)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Columns typed as Numeric/Currency will parse boolean values as Decimal (TDL-14448) - https://github.com/singer-io/tap-google-sheets/pull/73
Google Sheets standard numberType is given schema of 'multipleOf' for decimals (TDL-14454) - https://github.com/singer-io/tap-google-sheets/pull/74
Change transform logic for currency, boolean and datetime datatypes (TDL-18745) - https://github.com/singer-io/tap-google-sheets/pull/75
Discovery should look beyond effectiveValue and at effectiveFormat for discovering date-times (TDL-7096) - https://github.com/singer-io/tap-google-sheets/pull/76

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
