### PR TITLE
TDL-14450: fix inconsistency of empty cell for boolean

### DIFF
--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -426,8 +426,9 @@ def new_transform(self, data, typ, schema, path):
             return False, None
 
     elif typ == "boolean":
-        # return the data as string itself if the value is of type string
-        if isinstance(data, str) and data is not None:
+        if data is None: # returns "null" if data is none
+            return True, None
+        if isinstance(data, str):  # return the data as string itself if the value is of type string
             return True, data
         try:
             return True, bool(data)

--- a/tests/test_google_sheets_datatypes.py
+++ b/tests/test_google_sheets_datatypes.py
@@ -264,11 +264,6 @@ class DatatypesTest(GoogleSheetsBaseTest):
 
                         if test_case is None or 'empty' in test_case: # some rows we expect empty values rather than strings
 
-                            # BUG_TDL-14450 | https://jira.talendforge.org/browse/TDL-14450
-                            #                 The boolean empty rows are getting parsed as False...but only when it's not the last column
-                            if column == 'Boolean': # BUG_TDL-14450
-                                continue  # skip
-
                             # verify the expected rows are actually Null
                             self.assertIsNone(value)
 

--- a/tests/unittests/test_boolean_conversion.py
+++ b/tests/unittests/test_boolean_conversion.py
@@ -63,6 +63,15 @@ class TestBooleanDataType(unittest.TestCase):
         transformed_data = new_transform(transformer, data, "boolean", schema, '')
         self.assertEqual(transformed_data[1], True)
 
+    def test_null_returned_for_boolean_col(self):
+        '''
+        Verify that null value should not be replicated as False and it should be replicated as null.
+        '''
+        data = None
+        transformer = MockTransformer()
+        transformed_data = new_transform(transformer, data, "boolean", schema, '')
+        self.assertEqual(transformed_data[1], None)
+
     def test_date_time_with_serial_number_1_in_boolean_col(self):
         """
         Verify that dattime with serial number 1 returns string date instead of true.


### PR DESCRIPTION
# Description of change
[TDL-14450](https://jira.talendforge.org/browse/TDL-14450): fix Inconsistent treatment of empty rows for boolean type
- Updated boolean transform to consider null as a null and not a false.

# Manual QA steps
 - Verified that null value is parsed as a null for the boolean type.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
