### PR TITLE
TDL-19742 Run discover mode if catalog is not given in sync mode

### DIFF
--- a/tap_google_sheets/__init__.py
+++ b/tap_google_sheets/__init__.py
@@ -49,10 +49,10 @@ def main():
 
         if parsed_args.discover:
             do_discover(client, spreadsheet_id)
-        elif parsed_args.catalog:
+        else:
             sync(client=client,
                  config=config,
-                 catalog=parsed_args.catalog,
+                 catalog=parsed_args.catalog or discover(client, spreadsheet_id),
                  state=state)
 
 if __name__ == '__main__':

--- a/tests/unittests/test_catalog_in_sync.py
+++ b/tests/unittests/test_catalog_in_sync.py
@@ -1,4 +1,3 @@
-from shutil import ExecError
 import unittest
 from unittest import mock
 from tap_google_sheets import main
@@ -11,19 +10,17 @@ class MockedParseArgs:
     catalog = "test"
     
 @mock.patch("tap_google_sheets.discover")
-@mock.patch("tap_google_sheets.singer.utils.parse_args")
-@mock.patch("tap_google_sheets.GoogleClient.__enter__")
+@mock.patch("tap_google_sheets.singer.utils.parse_args", return_value=MockedParseArgs)
+@mock.patch("tap_google_sheets.GoogleClient.__enter__", return_value="test")
 @mock.patch("tap_google_sheets.sync")
 class TestCatalog(unittest.TestCase):
     def test_catalog_is_given_in_sync(self, mocked_sync, mocked_google_client, mocked_parse_args, mocked_discover):
         """
         To verify that if catalog is given in sync mode then run with catalog file
         """
-        MockedParseArgs.catalog = "test"
-        mocked_parse_args.return_value = MockedParseArgs
-        mocked_google_client.return_value = "test"
         main()
         mocked_sync.assert_called_with(client="test", config=MockedParseArgs.config, catalog="test", state={})
+        self.assertEqual(mocked_discover.call_count, 0, "discover function is not called expected times")
         
     def test_catalog_is_not_given_in_sync(self, mocked_sync, mocked_google_client, mocked_parse_args, mocked_discover):
         """
@@ -32,7 +29,6 @@ class TestCatalog(unittest.TestCase):
         # mocking discover function
         MockedParseArgs.catalog = ""
         mocked_discover.return_value = "test"
-        mocked_parse_args.return_value = MockedParseArgs
-        mocked_google_client.return_value = "test"
         main()
         mocked_sync.assert_called_with(client="test", config=MockedParseArgs.config, catalog="test", state={})
+        self.assertEqual(mocked_discover.call_count, 1, "discover function is not called expected times")

--- a/tests/unittests/test_catalog_in_sync.py
+++ b/tests/unittests/test_catalog_in_sync.py
@@ -1,0 +1,38 @@
+from shutil import ExecError
+import unittest
+from unittest import mock
+from tap_google_sheets import main
+
+
+class MockedParseArgs:
+    discover = False
+    config = {"client_id":"", "client_secret": "", "refresh_token": "", "user_agent": ""}
+    state = False
+    catalog = "test"
+    
+@mock.patch("tap_google_sheets.discover")
+@mock.patch("tap_google_sheets.singer.utils.parse_args")
+@mock.patch("tap_google_sheets.GoogleClient.__enter__")
+@mock.patch("tap_google_sheets.sync")
+class TestCatalog(unittest.TestCase):
+    def test_catalog_is_given_in_sync(self, mocked_sync, mocked_google_client, mocked_parse_args, mocked_discover):
+        """
+        To verify that if catalog is given in sync mode then run with catalog file
+        """
+        MockedParseArgs.catalog = "test"
+        mocked_parse_args.return_value = MockedParseArgs
+        mocked_google_client.return_value = "test"
+        main()
+        mocked_sync.assert_called_with(client="test", config=MockedParseArgs.config, catalog="test", state={})
+        
+    def test_catalog_is_not_given_in_sync(self, mocked_sync, mocked_google_client, mocked_parse_args, mocked_discover):
+        """
+        To verify that if catalog is not given in sync mode then run discover mode to generate catalog 
+        """
+        # mocking discover function
+        MockedParseArgs.catalog = ""
+        mocked_discover.return_value = "test"
+        mocked_parse_args.return_value = MockedParseArgs
+        mocked_google_client.return_value = "test"
+        main()
+        mocked_sync.assert_called_with(client="test", config=MockedParseArgs.config, catalog="test", state={})


### PR DESCRIPTION
# Description of change
 - Run discover mode and generate catalog when the catalog.json is not given in sync mode.
 - Write a unit test to justify the above scenario.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
