### PR TITLE
SAC-30291: Bump to singer-python 6.8.0 and use `versions` in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.0
+  * Bump singer-python to 6.8.0 and update tests to use renamed state key `versions` [#105](https://github.com/singer-io/tap-google-sheets/pull/105)
+
+## 3.2.0
+  * Update to new singer-python state functions and keep activate_versions separate from bookmarks in state [#104](https://github.com/singer-io/tap-google-sheets/pull/104)
+
 ## 3.1.2
   * Increase the wait time while retrying on failure [#102](https://github.com/singer-io/tap-google-sheets/pull/102)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-sheets',
-      version='3.2.0',
+      version='3.3.0',
       description='Singer.io tap for extracting data from the Google Sheets v4 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -11,7 +11,7 @@ setup(name='tap-google-sheets',
       install_requires=[
           'backoff==2.2.1',
           'requests==2.32.4',
-          'singer-python==6.7.0'
+          'singer-python==6.8.0'
       ],
       extras_require={
           'test': [

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -68,7 +68,7 @@ def write_record(stream_name, record, time_extracted, version=None):
 def get_version(state, stream, default):
     """
     First look for the stream under the 'bookmarks' key for backwards compatibility.
-    Then look for stream in 'activate_versions' (modern structure of state).
+    Then look for stream in 'versions' (modern structure of state).
     Use default if not found.
     """
     return state.get('bookmarks', {}).get(stream) or singer.get_version(state, stream, default)
@@ -76,7 +76,7 @@ def get_version(state, stream, default):
 def clear_bookmark_set_version(state, stream, version):
     """
     Clear the bookmark for the stream and write the state
-    with the activate_version
+    with the versions
     """
     if state.get('bookmarks',{}).get(stream):
         state['bookmarks'].pop(stream, None)
@@ -84,7 +84,7 @@ def clear_bookmark_set_version(state, stream, version):
         state = singer.clear_version(state, stream)
     else:
         state = singer.set_version(state, stream, version)
-    LOGGER.info('Write state for stream: {}, activate_version: {}'.format(stream, version))
+    LOGGER.info('Write state for stream: {}, versions: {}'.format(stream, version))
     singer.write_state(state)
 
 def get_abs_path(path):

--- a/tests/test_google_sheets_bookmarks.py
+++ b/tests/test_google_sheets_bookmarks.py
@@ -48,7 +48,7 @@ class BookmarksTest(GoogleSheetsBaseTest):
                 self.assertEqual('activate_version', sync1_message_actions[0])
                 self.assertEqual('activate_version', sync1_message_actions[-1])
                 self.assertSetEqual({'upsert'}, set(sync1_message_actions[1:-1]))
-                self.assertIn(stream, state["activate_versions"].keys())
+                self.assertIn(stream, state["versions"].keys())
 
         new_state = {'bookmarks': {list(final_test_streams)[0]: 123,
                                    "unselected_stream": 111}}
@@ -67,10 +67,10 @@ class BookmarksTest(GoogleSheetsBaseTest):
             with self.subTest(stream=stream):
                 sync1_message_actions = [message['action'] for message in synced_records_2[stream]['messages']]
                 self.assertNotIn(stream, state_2["bookmarks"].keys())
-                self.assertIn(stream, state_2["activate_versions"].keys())
+                self.assertIn(stream, state_2["versions"].keys())
 
         self.assertIn("unselected_stream", state_2["bookmarks"].keys())
-        self.assertNotIn("unselected_stream", state_2["activate_versions"].keys())
+        self.assertNotIn("unselected_stream", state_2["versions"].keys())
 
     def starter(self):
         """


### PR DESCRIPTION
# Description of change
V 3.3.0
- Bump singer-python to 6.8.0
- Update tests and log lines to refer to `versions` in state instead of `activate_versions`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
